### PR TITLE
Add yt-dlp flag to prevent timed out error

### DIFF
--- a/root/scripts/MovieExtras.bash
+++ b/root/scripts/MovieExtras.bash
@@ -5,6 +5,7 @@ arrItemId=$radarr_movie_id
 tmdbApiKey="3b7751e3179f796565d88fdb2fcdf426"
 autoScan="false"
 updatePlex="false"
+ytdlpExtraOpts="--user-agent facebookexternalhit/1.1"
 
 if [ ! -z "$1" ]; then
     arrItemId="$1"
@@ -204,9 +205,9 @@ do
 
         log "$itemTitle :: $i of $tmdbVideosListDataIdsCount :: $tmdbExtraType :: $tmdbExtraTitle ($tmdbExtraKey) :: Downloading (yt-dlp :: $videoFormat)..."
         if [ ! -z "$cookiesFile" ]; then
-            yt-dlp -f "$videoFormat" --no-video-multistreams --cookies "$cookiesFile" -o "$finalPath/$finalFileName" --write-sub --sub-lang $videoLanguages --embed-subs --merge-output-format mkv --no-mtime --geo-bypass "https://www.youtube.com/watch?v=$tmdbExtraKey"
+            yt-dlp -f "$videoFormat" --no-video-multistreams --cookies "$cookiesFile" -o "$finalPath/$finalFileName" --write-sub --sub-lang $videoLanguages --embed-subs --merge-output-format mkv --no-mtime --geo-bypass $ytdlpExtraOpts "https://www.youtube.com/watch?v=$tmdbExtraKey"
         else
-            yt-dlp -f "$videoFormat" --no-video-multistreams -o "$finalPath/$finalFileName" --write-sub --sub-lang $videoLanguages --embed-subs --merge-output-format mkv --no-mtime --geo-bypass "https://www.youtube.com/watch?v=$tmdbExtraKey"
+            yt-dlp -f "$videoFormat" --no-video-multistreams -o "$finalPath/$finalFileName" --write-sub --sub-lang $videoLanguages --embed-subs --merge-output-format mkv --no-mtime --geo-bypass $ytdlpExtraOpts "https://www.youtube.com/watch?v=$tmdbExtraKey"
         fi
         if [ -f "$finalPath/$finalFileName.mkv" ]; then
             log "$itemTitle :: $i of $tmdbVideosListDataIdsCount :: $tmdbExtraType :: $tmdbExtraTitle ($tmdbExtraKey) :: Compete"


### PR DESCRIPTION
I'm having issues to download from `yt-dlp`.

Looking around I found this issue  https://github.com/yt-dlp/yt-dlp/issues/2396#issuecomment-1018262631 that introduces a workaround by adding a `--user-agent facebookexternalhit/1.1` flag to `yt-dlp`.

As it worked on my side and I don't see an issue using it by default, I'm sending this PR.

I've introduced this flag using a new variable at the beginning, making it easier to alter or remove it in future if required.